### PR TITLE
Assemble project on each push on CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,11 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the project
+      run: ./gradlew assemble


### PR DESCRIPTION
As discusses in [this PR](https://github.com/Kotlin/mpp-example/pull/31#issuecomment-566916403) this will add a GitHub Actions to the repo.

For the first step it will simply use the macos runner (which has preinstalled Xcode (for the iOS build) and the Android SDK (for the android build)). It has also preinstalled Java and stuff. See also [this help page](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners) for more information.

I simply added the `assemble` task to test if everything works correctly.
But I guess we need some fine grained tasks here. 
Maybe the `testReleaseUnitTest` to test the Android stuff and `testiOS` for the ios stuff.
But I'm not sure if the simulator is preinstalled and run out of the box.. so for now assemble is good enough I guess.